### PR TITLE
Fix editing titles with similar to old title

### DIFF
--- a/src/apollo/gql/projects.js
+++ b/src/apollo/gql/projects.js
@@ -454,8 +454,8 @@ const WALLET_ADDRESS_IS_VALID = gql`
 `
 
 const TITLE_IS_VALID = gql`
-  query IsValidTitleForProject($title: String!) {
-    isValidTitleForProject(title: $title)
+  query IsValidTitleForProject($title: String!, $projectId : Float) {
+    isValidTitleForProject(title: $title, projectId : $projectId)
   }
 `
 

--- a/src/components/account/projectEdition/index.js
+++ b/src/components/account/projectEdition/index.js
@@ -116,7 +116,8 @@ function ProjectEdition(props) {
         await client.query({
           query: TITLE_IS_VALID,
           variables: {
-            title: data.editTitle
+            title: data.editTitle,
+            projectId: Number(project.id)
           }
         })
       }


### PR DESCRIPTION
related to Giveth/impact-graph#179

@RamRamez 
I have changed the query and added a projected , then for edit you should pass the projected then backend will know to permit you titles similar the older one
```
{
  isValidTitleForProject(title:"test upload    phOTO", projectId:7)
}
```